### PR TITLE
[Don't Merge] - Set Global Axios defaults

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+REACT_APP_API_URL_LOCAL=http://localhost:5000
+REACT_APP_API_URL_SOCKET=https://socket.graphitedocs.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Graphite
 
-Graphite is a secure, private, and encrypted alternative to Google's G-Suite. Using [Blockstack's](http://blockstack.org) developer tools and protocol, Graphite gives people control over their identity. People get all the convenience of cloud computing with none of the privacy tradeoffs. 
+Graphite is a secure, private, and encrypted alternative to Google's G-Suite. Using [Blockstack's](http://blockstack.org) developer tools and protocol, Graphite gives people control over their identity. People get all the convenience of cloud computing with none of the privacy tradeoffs.
 
 Check it out at http://app.graphitedocs.com
 
@@ -17,6 +17,7 @@ Steps to install:
 1) Clone the repo.
 2) Run `npm install`
 3) Run `npm run start`
+4) Run `cp .env.sample .env`
 
 **Note: Local development will result in CORS errors on authentication. Use a CORS browser extension to get around this. Future version will eliminate this need and when pushed to a hosted site, the CORS error is resolved.**  
 
@@ -24,14 +25,14 @@ Steps to install:
 
 It is possible to run Graphite locally and access Graphite Pro features. There are two options:  
 
-1. Update the code in the `src/components/pro/helpers/account.js` file on line 60. The `baseURL` variable can simply be updated to point to https://socket.graphitedocs.com at all times.  
+1. Update the code in the `src/index.js`.  Set the `axios.defaults.baseURL` to `process.env.REACT_APP_API_URL_SOCKET` (https://socket.graphitedocs.com)
 2. Clone and run the `graphite-server`. This server handles websockets and Graphire Pro requires. It is available at [https://github.com/graphite-docs/graphite-server](https://github.com/graphite-docs/graphite-server).
 
 # Technical Architecture  
-There is a lot that goes into making Graphite work well while hiding the complexities of encryption behind the scenes. But at the same time, it's important to understand how that complexity works so that people can audit and adopt similar approaches elsewhere. 
+There is a lot that goes into making Graphite work well while hiding the complexities of encryption behind the scenes. But at the same time, it's important to understand how that complexity works so that people can audit and adopt similar approaches elsewhere.
 
 ### Identity  
-When creating a user account, people are directed to the Blockstack Browser. While the name is a bit of a misnomer, the Blockstack Browser is an authenticator. The best way to think of it is like the little window that pops up when you sign into applications using Google or Facebook. The difference here is that the Blockstack Browser is simply verifying or generating application-specific encryption keys for you to use within Graphite. 
+When creating a user account, people are directed to the Blockstack Browser. While the name is a bit of a misnomer, the Blockstack Browser is an authenticator. The best way to think of it is like the little window that pops up when you sign into applications using Google or Facebook. The difference here is that the Blockstack Browser is simply verifying or generating application-specific encryption keys for you to use within Graphite.
 
 Basic flow for a new user:   
 
@@ -42,63 +43,63 @@ Basic flow for a new user:
 * Master keychain created   
 * Application-specific encryption keys generated  
 * Storage hub selected and specified in profile  
-* Authentication response included in a redirect to Graphite 
+* Authentication response included in a redirect to Graphite
 
-What's actually happening above? 
+What's actually happening above?
 
 If a user has never used an application built on Blockstack's protocol, they'll need to select a user name. Let's explore that first.  
 
 **Username selection and registration**  
 
-Initially, a username is created for free as a sponsored name under the `id.blockstack` name within the `.blockstack` namespace. The best way to think of names are like website domains, and the best way to think of namespaces are like top-level domains (.com, .org, etc). Because all name registrations require a transaction on the bitcoin blockchain (this is how these names become wholly owned by the people who register them and not by apps like Graphite), a payment is required. However, by issuing sponsored names under and existing name, these name registrations can be batched together. This allows hundreds of names to be registered at once, thus bringing down the cost significantly. 
+Initially, a username is created for free as a sponsored name under the `id.blockstack` name within the `.blockstack` namespace. The best way to think of names are like website domains, and the best way to think of namespaces are like top-level domains (.com, .org, etc). Because all name registrations require a transaction on the bitcoin blockchain (this is how these names become wholly owned by the people who register them and not by apps like Graphite), a payment is required. However, by issuing sponsored names under and existing name, these name registrations can be batched together. This allows hundreds of names to be registered at once, thus bringing down the cost significantly.
 
-Example: `justin.id.blockstack` is a sponsored name under the `id.blockstack` name within the `blockstack` namespace. Although the owner of `id.blockstack` controls the availability of name registrations through that name, once a name is created, it is entirely owned and controlled by the person using it. 
+Example: `justin.id.blockstack` is a sponsored name under the `id.blockstack` name within the `blockstack` namespace. Although the owner of `id.blockstack` controls the availability of name registrations through that name, once a name is created, it is entirely owned and controlled by the person using it.
 
-People have the opportunity to create additional names, and those names do not have to be sponsored names. It's important to note that as of this time, any names created outside the sponsored `id.blockstack` name will require payment from the user to issue the name transaction on the blockchain. 
+People have the opportunity to create additional names, and those names do not have to be sponsored names. It's important to note that as of this time, any names created outside the sponsored `id.blockstack` name will require payment from the user to issue the name transaction on the blockchain.
 
 In a soon-to-be-released version of Graphite's authentication system, users will simply be able to select a username and enter a password. The process described above will happen behind the scenes and without the user ever having to leave Graphite's web app.  
 
 **Master keychain creation**  
-For brand new users, a keychain is created. This keychain is a combination of things. It helps generate their publicly available profile file, but it also includes sensitive information such as master private key, master payment key, and a seed phrase. 
+For brand new users, a keychain is created. This keychain is a combination of things. It helps generate their publicly available profile file, but it also includes sensitive information such as master private key, master payment key, and a seed phrase.
 
-Currently, each user must record the seed phrase and keep it somewhere safe. *Loss of the seed phrase equates to loss of data*. 
+Currently, each user must record the seed phrase and keep it somewhere safe. *Loss of the seed phrase equates to loss of data*.
 
-This keychain is created client-side and encrypted. 
+This keychain is created client-side and encrypted.
 
 **Application-specific encryption keys generated**  
-Because Blockstack's protocol is designed to be used with a single username across multiple applications, the user is presented with application-specific encryption keys. These keys are used only within the app the person is logging into. In the case of Graphite, Graphite-specific keys are used for encryption and decryption. If someone were to try to use those keys in another app, they would not work. 
+Because Blockstack's protocol is designed to be used with a single username across multiple applications, the user is presented with application-specific encryption keys. These keys are used only within the app the person is logging into. In the case of Graphite, Graphite-specific keys are used for encryption and decryption. If someone were to try to use those keys in another app, they would not work.
 
-These keys, of course, are unique per person and are derived by a combination of the verification of Graphite's application origin (https://app.graphitedocs.com) and the person's master seed phrase. 
+These keys, of course, are unique per person and are derived by a combination of the verification of Graphite's application origin (https://app.graphitedocs.com) and the person's master seed phrase.
 
-Because of this derivation process, a user never has to memorize or store their Graphite-specific encryption keys. As long as they have their seed phrase somewhere safe, they will always be able to encrypt and decrypt data behind the scenes with the same simplicity as using unencrypted Google Products. 
+Because of this derivation process, a user never has to memorize or store their Graphite-specific encryption keys. As long as they have their seed phrase somewhere safe, they will always be able to encrypt and decrypt data behind the scenes with the same simplicity as using unencrypted Google Products.
 
 ### Storage
 
 **Storage hub selected and specified in profile**  
-While not all applications buuilding with Blockstack's protocol offer this, Graphite offers people the opportunity to provide a user-selected storage hub URL. Should a user not want to deal with the technical requirements of configuring and deploying a storage hub, they can simply use Blockstack's sponsored storage hub for free. All data is encrypted before being sent to Blockstack's sponsored hub, so people can freely work and communicate without fear of snooping or data breaches. 
+While not all applications buuilding with Blockstack's protocol offer this, Graphite offers people the opportunity to provide a user-selected storage hub URL. Should a user not want to deal with the technical requirements of configuring and deploying a storage hub, they can simply use Blockstack's sponsored storage hub for free. All data is encrypted before being sent to Blockstack's sponsored hub, so people can freely work and communicate without fear of snooping or data breaches.
 
-If a person would like to run their own storage hub, they can follow the instructions here: [Gaia Storage](https://github.com/blockstack/gaia/). 
+If a person would like to run their own storage hub, they can follow the instructions here: [Gaia Storage](https://github.com/blockstack/gaia/).
 
 *Notes about storage and Graphite Pro plans:*  
 Paying users of Graphite's enterprise offering, Graphite Pro, will have pointer information stored in a Graphite managed database. This database contains no personal information and simply allows teams to work together by signalling where a file is currently located (i.e. which users on the account has the most recent updates in their storage hub).
 
 ### Collaboration  
-To get a sense for how sharing of documents and files works in Graphite at a base level, consider the diagram below. 
+To get a sense for how sharing of documents and files works in Graphite at a base level, consider the diagram below.
 
 ![](https://blog.graphitedocs.com/content/images/downloaded_images/Collaborative-Writing-With-User-Owned-Storage-and-Encryption/1-9UV_B4MirauPOQsrBZzMWA.png)
 
-Essentially, every file or document that is shared is copied then encrypted with the recipient's public key. This is true of real-time collaboration as well, but with the added convenience of back and forth updates possible in real time. 
+Essentially, every file or document that is shared is copied then encrypted with the recipient's public key. This is true of real-time collaboration as well, but with the added convenience of back and forth updates possible in real time.
 
 Graphite uses a websockets server to manage real-time collaboration. The server uses a secure `wss` connections (the equivalent of tls connections for web browsers). No data is stored on the server or sent anywhere other than to the other collaborators. This is all verifiable by reviewing the open source code for Graphite's server [here](https://github.com/graphite-docs/graphite-server).
 
 ### Graphite Pro  
-Paying customer under Graphite's enterprise plan, Graphite Pro, have added benefits such as team management, roles and permissions, and team sharing. To enable these features, Graphite takes a security-first approach while still recognizing the need for convenience. 
+Paying customer under Graphite's enterprise plan, Graphite Pro, have added benefits such as team management, roles and permissions, and team sharing. To enable these features, Graphite takes a security-first approach while still recognizing the need for convenience.
 
-When a team is created, encryption keys for that team are also created. This happens client-side. When a team member is added to the team an email invite is sent which includes a token that allows the team member to receive and store and encrypted copy of the team-specific encryption keys in their storage hub. 
+When a team is created, encryption keys for that team are also created. This happens client-side. When a team member is added to the team an email invite is sent which includes a token that allows the team member to receive and store and encrypted copy of the team-specific encryption keys in their storage hub.
 
-Any files, forms, or documents shared amongst a team are encrypted with team-specific keys. Because Graphite Pro also makes use of a server and a database for pointer files, additional security is put in place to verify the authenticity of an API call to request information about a file's storage location. Should a teammate be removed from the team, the database knows about this, the client knows about this, and the encryption keys for the team are rotated. 
+Any files, forms, or documents shared amongst a team are encrypted with team-specific keys. Because Graphite Pro also makes use of a server and a database for pointer files, additional security is put in place to verify the authenticity of an API call to request information about a file's storage location. Should a teammate be removed from the team, the database knows about this, the client knows about this, and the encryption keys for the team are rotated.
 
-To get an even better sense of how this all works, please review the blog post that outlines [Graphite Pro](https://blog.graphitedocs.com/re-introducing-graphite-pro/). 
+To get an even better sense of how this all works, please review the blog post that outlines [Graphite Pro](https://blog.graphitedocs.com/re-introducing-graphite-pro/).
 
 # Motivation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3019,12 +3019,12 @@
       }
     },
     "browserslist": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.4.tgz",
-      "integrity": "sha512-ErJT8qGfRt/VWHSr1HeqZzz50DvxHtr1fVL1m5wf20aGrG8e1ce8fpZ2EjZEfs09DDZYSvtRaDlMpWslBf8Low==",
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+      "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
       "requires": {
-        "caniuse-lite": "^1.0.30000981",
-        "electron-to-chromium": "^1.3.188",
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
         "node-releases": "^1.1.25"
       }
     },
@@ -3225,9 +3225,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000983",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000983.tgz",
-      "integrity": "sha512-/llD1bZ6qwNkt41AsvjsmwNOoA4ZB+8iqmf5LVyeSXuBODT/hAMFNVOh84NdUzoiYiSKqo5vQ3ZzeYHSi/olDQ=="
+      "version": "1.0.30000984",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000984.tgz",
+      "integrity": "sha512-n5tKOjMaZ1fksIpQbjERuqCyfgec/m9pferkFQbLmWtqLUdmt12hNhjSwsmPdqeiG2NkITOQhr1VYIwWSAceiA=="
     },
     "canvg": {
       "version": "1.5.3",
@@ -4813,11 +4813,11 @@
       }
     },
     "css-tree": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
       "requires": {
-        "mdn-data": "~1.1.0",
+        "mdn-data": "2.0.4",
         "source-map": "^0.5.3"
       },
       "dependencies": {
@@ -4832,11 +4832,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
-    },
-    "css-url-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-      "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
     },
     "css-what": {
       "version": "2.1.3",
@@ -5089,6 +5084,11 @@
             "mdn-data": "~1.1.0",
             "source-map": "^0.5.3"
           }
+        },
+        "mdn-data": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
         },
         "source-map": {
           "version": "0.5.7",
@@ -5669,9 +5669,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.189",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.189.tgz",
-      "integrity": "sha512-C26Kv6/rLNmGDaPR5HORMtTQat9aWBBKjQk9aFtN1Bk6cQBSw8cYdsel/mcrQlNlMMjt1sAKsTYqf77+sK2uTw=="
+      "version": "1.3.191",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz",
+      "integrity": "sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ=="
     },
     "elliptic": {
       "version": "6.5.0",
@@ -5954,9 +5954,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -6270,9 +6270,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -6986,9 +6989,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -8354,9 +8357,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -11824,9 +11827,9 @@
       }
     },
     "mdn-data": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-      "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -12064,9 +12067,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -13113,9 +13116,9 @@
       }
     },
     "portfinder": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
-      "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
+      "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
       "requires": {
         "async": "^1.5.2",
         "debug": "^2.2.0",
@@ -14598,11 +14601,11 @@
       }
     },
     "postcss-initial": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.0.tgz",
-      "integrity": "sha512-WzrqZ5nG9R9fUtrA+we92R4jhVvEB32IIRTzfIG/PLL8UV4CvbF1ugTEHEFX6vWxl41Xt5RTCJPEZkuWzrOM+Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.1.tgz",
+      "integrity": "sha512-I2Sz83ZSHybMNh02xQDK609lZ1/QOyYeuizCjzEhlMgeV/HcDJapQiH4yTqLjZss0X6/6VvKFXUeObaHpJoINw==",
       "requires": {
-        "lodash.template": "^4.2.4",
+        "lodash.template": "^4.5.0",
         "postcss": "^7.0.2"
       },
       "dependencies": {
@@ -14733,9 +14736,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -18666,9 +18669,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -19797,9 +19800,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -19936,16 +19939,15 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "svgo": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
-      "integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "^1.1.0",
+        "css-tree": "1.0.0-alpha.33",
         "csso": "^3.5.1",
         "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
@@ -20077,9 +20079,9 @@
       }
     },
     "swagger-ui-react": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-3.23.0.tgz",
-      "integrity": "sha512-yNaQrSKfxk0yT7DSox5wddocYWsz2H5o8KT9CA4pw1gXE1jkKSsFS7DLwhIdiAElH+BBfRguS9ypMJ5N9yJQqA==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-3.23.1.tgz",
+      "integrity": "sha512-CXeyfeccrwSNhIhGGPtx1v4oWlI4pujLJLw4WtloeYKG2ntkwMsyA9QeETIaJYhOvEdJs9zHfbNpJvzO2Qeyzw==",
       "requires": {
         "@braintree/sanitize-url": "^2.0.2",
         "@kyleshockey/js-yaml": "^1.0.1",
@@ -20151,9 +20153,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -20228,9 +20230,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -20805,9 +20807,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -20842,9 +20844,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "use-force-update": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/use-force-update/-/use-force-update-1.0.6.tgz",
-      "integrity": "sha512-RekeU3l01HIJkwRKouQm+mQ++vWaTRw2qMLPrHB8zupXYKK5a6DkTESm3zjXlPlPnF22Ug1cI/7LPtqPFObSwA=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/use-force-update/-/use-force-update-1.0.7.tgz",
+      "integrity": "sha512-k5dppYhO+I5X/cd7ildbrzeMZJkWwdAh5adaIk0qKN2euh7J0h2GBGBcB4QZ385eyHHnp7LIygvebdRx3XKdwA=="
     },
     "utf8-bytes": {
       "version": "0.0.1",
@@ -21155,9 +21157,9 @@
           "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
         },
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -21481,9 +21483,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",

--- a/src/components/docs/helpers/publicDoc.js
+++ b/src/components/docs/helpers/publicDoc.js
@@ -3,11 +3,12 @@ import { Value } from 'slate';
 const axios = require('axios');
 const blockstack = require('blockstack');
 export function fetchData(){
-    const user = window.location.href.split('docs/')[1].split('-')[0];
+    const user = window.location.href.split('docs/')[1].split('&id=')[0];
     blockstack.lookupProfile(user, "https://core.blockstack.org/v1/names")
     .then((profile) => {
       setGlobal({ url: profile.apps[window.location.origin]}, () => {
-        const id = window.location.href.split('docs/')[1].split('-')[1].split('#')[0]
+        const id = window.location.href.split('docs/')[1].split('&id=')[1].split('#')[0]
+        console.log(id);
         axios.get(`${getGlobal().url}public/${id}.json`)
         .then((response) => {
             console.log(response)
@@ -50,7 +51,7 @@ export function handlePubChange(change) {
 }
 
 export function pollForChanges() {
-  const user = window.location.href.split('docs/')[1].split('-')[0];
+  const user = window.location.href.split('docs/')[1].split('&id=')[0];
     blockstack.lookupProfile(user, "https://core.blockstack.org/v1/names")
     .then((profile) => {
       setGlobal({ url: profile.apps[window.location.origin]}, () => {

--- a/src/components/docs/helpers/shareDoc.js
+++ b/src/components/docs/helpers/shareDoc.js
@@ -83,7 +83,7 @@ export function sharePublicly(params) {
     window.location.href.includes("new") ? id = window.location.href.split("new/")[1] : id = window.location.href.split("documents/")[1];
     const directory = "public/";
     const file = directory + id + ".json";
-    const link = `${window.location.origin}/shared/docs/${user}-${id}`;
+    const link = `${window.location.origin}/shared/docs/${user}&id=${id}`;
 
     try {
         let pubDocParams = {

--- a/src/components/docs/helpers/singleDoc.js
+++ b/src/components/docs/helpers/singleDoc.js
@@ -15,7 +15,6 @@ import axios from 'axios';
 const wordCount = require('html-word-count')
 const uuid = require('uuidv4');
 const lzjs = require('lzjs');
-const environment = window.location.origin;
 const blockstack = require('blockstack');
 
 var timer = null;
@@ -332,15 +331,12 @@ export async function shareWithTeam(data) {
     pubKey: getPublicKeyFromPrivate(privateKey)
   }
 
-  let serverUrl;
     const tokenData = {
         profile: userSession.loadUserData().profile,
         username: userSession.loadUserData().username,
         pubKey: getPublicKeyFromPrivate(privateKey)
     }
     const bearer = blockstack.signProfileToken(tokenData, userSession.loadUserData().appPrivateKey);
-
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
     const headerObj = {
         headers: {
             'Access-Control-Allow-Origin': '*',
@@ -348,7 +344,7 @@ export async function shareWithTeam(data) {
             'Authorization': bearer
         },
     }
-    axios.post(`${serverUrl}/account/organization/${proOrgInfo.orgId}/documents`, JSON.stringify(syncedDoc), headerObj)
+    axios.post(`/account/organization/${proOrgInfo.orgId}/documents`, JSON.stringify(syncedDoc), headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {

--- a/src/components/docs/helpers/teamDocs.js
+++ b/src/components/docs/helpers/teamDocs.js
@@ -3,7 +3,6 @@ import { getGlobal } from 'reactn';
 import { ToastsStore} from 'react-toasts';
 import { getPublicKeyFromPrivate } from 'blockstack/lib/keys';
 import { loadData } from '../../shared/helpers/accountContext';
-const environment = window.location.origin;
 const blockstack = require('blockstack');
 
 export function deleteTeamDoc(data) {
@@ -12,23 +11,21 @@ export function deleteTeamDoc(data) {
     const privateKey = userSession.loadUserData().appPrivateKey;
     const pubKey = getPublicKeyFromPrivate(privateKey);
 
-    let serverUrl;
     const tokenData = {
-        profile: userSession.loadUserData().profile, 
-        username: userSession.loadUserData().username, 
+        profile: userSession.loadUserData().profile,
+        username: userSession.loadUserData().username,
         pubKey
     }
     const bearer = blockstack.signProfileToken(tokenData, userSession.loadUserData().appPrivateKey);
 
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
-    axios.delete(`${serverUrl}/account/organization/${proOrgInfo.orgId}/teams/${data.teamId}/documents/${data.docId}?pubKey=${pubKey}`, headerObj)
+    axios.delete(`/account/organization/${proOrgInfo.orgId}/teams/${data.teamId}/documents/${data.docId}?pubKey=${pubKey}`, headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {

--- a/src/components/docs/views/editor/MenuBar.js
+++ b/src/components/docs/views/editor/MenuBar.js
@@ -244,7 +244,7 @@ export default class MenuBar extends React.Component {
                                         {singleDoc.readOnly === true ? "This shared document is read-only." : "This shared document is editable."}
                                       </p>
                                       <div>
-                                        <p><a href={`${window.location.origin}/shared/docs/${userSession.loadUserData().username}-${docId}`}>{`${window.location.origin}/shared/docs/${userSession.loadUserData().username}-${docId}`}</a></p>
+                                        <p><a href={`${window.location.origin}/shared/docs/${userSession.loadUserData().username}&id=${docId}`}>{`${window.location.origin}/shared/docs/${userSession.loadUserData().username}&id=${docId}`}</a></p>
                                       </div>
                                     </div>
                                     :

--- a/src/components/docs/views/editor/SocketEditor.js
+++ b/src/components/docs/views/editor/SocketEditor.js
@@ -1,14 +1,14 @@
 import React, { Component } from 'reactn';
 import socketIOClient from 'socket.io-client';
 import SlateEditor from './Editor';
-let serverhost = window.location.href.includes("local") ? "http://localhost:5000" : "https://socket.graphitedocs.com";
+import axios from 'axios';
 
 class SocketEditor extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      endpoint: serverhost,
+      endpoint: axios.defaults.baseURL,
       showCollab: false,
       uniqueID: ""
     }
@@ -19,7 +19,7 @@ class SocketEditor extends Component {
     } else {
       this.uniqueID = Math.round(Math.random() * 1000000000000);
     }
-    
+
     this.socket = socketIOClient(this.state.endpoint);
     this.socket.on('update content', data => {
       const content = JSON.parse(data)

--- a/src/components/docs/views/editor/SocketEditor.js
+++ b/src/components/docs/views/editor/SocketEditor.js
@@ -45,7 +45,7 @@ class SocketEditor extends Component {
     if(window.location.href.includes('docInfo')) {
         room = room = window.location.href.split('id=')[1];
     } else if(window.location.href.includes('shared')) {
-        room = window.location.href.split('shared/docs/')[1].split('-')[1]
+        room = window.location.href.split('shared/docs/')[1].split('&id=')[1]
     } else {
       if(window.location.href.includes("new")) {
         room = window.location.href.split("new/")[1];

--- a/src/components/files/helpers/singleVaultFile.js
+++ b/src/components/files/helpers/singleVaultFile.js
@@ -16,7 +16,6 @@ const Papa = require('papaparse');
 let abuf4;
 var FileSaver = require('file-saver');
 let timer = null;
-const environment = window.location.origin;
 
 export async function loadSingleVaultFile() {
     let wb;
@@ -52,7 +51,7 @@ export async function loadSingleVaultFile() {
         const encryptedFile = await fetchData(teamFile);
         const decryptedFile = userSession.decryptContent(JSON.parse(encryptedFile), {privateKey: JSON.parse(fetchedKeys).private});
         await setGlobal({
-          singleFile: JSON.parse(decryptedFile), 
+          singleFile: JSON.parse(decryptedFile),
           file: JSON.parse(decryptedFile),
           name: JSON.parse(decryptedFile).name,
           type: JSON.parse(decryptedFile).file.type,
@@ -92,7 +91,7 @@ export async function loadSingleVaultFile() {
           wb = XLSX.read(abuf4, { type: "buffer" });
           first_worksheet = wb.Sheets[wb.SheetNames[0]];
           data = XLSX.utils.sheet_to_json(first_worksheet, { header: 1 });
-          
+
           setGlobal({ grid: data });
           setGlobal({ loading: "hide", show: "" });
         }
@@ -103,11 +102,11 @@ export async function loadSingleVaultFile() {
           setGlobal({ loading: "hide", show: "" });
         }
         setGlobal({ loading: false });
-      } else { 
+      } else {
         console.log("No team files...")
         //Need to figure out how to handle this better.
-      } 
-      
+      }
+
       } else {
         const fileId = window.location.href.split('files/')[1];
         const file = `${fileId}.json`
@@ -118,9 +117,9 @@ export async function loadSingleVaultFile() {
 
         let thisFile = await fetchData(fileParams);
         await setGlobal({
-            file: JSON.parse(thisFile), 
+            file: JSON.parse(thisFile),
             singleFile: JSON.parse(thisFile),
-            name: JSON.parse(thisFile).name, 
+            name: JSON.parse(thisFile).name,
             type: JSON.parse(thisFile).type,
             link: JSON.parse(thisFile).link
         })
@@ -158,7 +157,7 @@ export async function loadSingleVaultFile() {
             wb = XLSX.read(abuf4, { type: "buffer" });
             first_worksheet = wb.Sheets[wb.SheetNames[0]];
             data = XLSX.utils.sheet_to_json(first_worksheet, { header: 1 });
-            
+
             setGlobal({ grid: data });
             setGlobal({ loading: "hide", show: "" });
           }
@@ -187,10 +186,10 @@ export async function downloadPDF() {
     oReq.onload = function() {
         // Once the file is downloaded, open a new window with the PDF
         // Remember to allow the POP-UPS in your browser
-        var file = new Blob([oReq.response], { 
-            type: 'application/pdf' 
+        var file = new Blob([oReq.response], {
+            type: 'application/pdf'
         });
-        
+
         // Generate file download directly in the browser !
         FileSaver.saveAs(file, getGlobal().name);
     };
@@ -211,18 +210,18 @@ export async function signWithBlockusign(fileId) {
     const options = { username: userSession.loadUserData().username, zoneFileLookupURL: "https://core.blockstack.org/v1/names", decrypt: false, app: 'https://blockusign.co'}
     try {
         let dataParams = {
-            fileName: 'key.json', 
-            options, 
+            fileName: 'key.json',
+            options,
             decrypt: false
         }
         let thisKey = await fetchData(dataParams);
         if(thisKey) {
             const data = JSON.stringify(getGlobal().singleFile);
             const encryptedData = userSession.encryptContent(data, {publicKey: JSON.parse(thisKey)})
-            
+
             let postParams = {
-                fileName: `blockusign/${fileId}`, 
-                encrypt: false, 
+                fileName: `blockusign/${fileId}`,
+                encrypt: false,
                 body: JSON.stringify(encryptedData)
             }
 
@@ -242,12 +241,12 @@ export async function signWithBlockusign(fileId) {
     let singleFile = await getGlobal().singleFile;
     singleFile["publicVaultFile"] = true;
     await setGlobal({ singleFile, publicVaultFile: true });
-    //First we save the single file with its updates. 
+    //First we save the single file with its updates.
     await saveFile();
     //Now we save the file publicly
     const publicParams = {
-        fileName, 
-        encrypt: false, 
+        fileName,
+        encrypt: false,
         body: JSON.stringify(singleFile)
     }
     const postedPublic = await postData(publicParams);
@@ -266,8 +265,8 @@ export async function signWithBlockusign(fileId) {
     await saveFile();
 
     let publicParams = {
-        fileName, 
-        encrypt: false, 
+        fileName,
+        encrypt: false,
         body: JSON.stringify({})
     }
     const postedPublic = await postData(publicParams);
@@ -281,15 +280,15 @@ export async function signWithBlockusign(fileId) {
     let singleFile = await getGlobal().singleFile;
     singleFile["name"] = name;
     await setGlobal({ name, singleFile });
-    clearTimeout(timer); 
+    clearTimeout(timer);
     timer = setTimeout(() => saveFile(), 1500);
   }
 
   export async function saveFile() {
     let singleFile = await getGlobal().singleFile;
     let singleFileParams = {
-        fileName: `${window.location.href.split('files/')[1]}.json`, 
-        encrypt: true, 
+        fileName: `${window.location.href.split('files/')[1]}.json`,
+        encrypt: true,
         body: JSON.stringify(singleFile)
     }
     const postedFile = await postData(singleFileParams);
@@ -302,7 +301,7 @@ export async function signWithBlockusign(fileId) {
     let file = await getGlobal().singleFile;
     const indexObject = {
         uploaded: file.uploaded,
-        timestamp: Date.now(), 
+        timestamp: Date.now(),
         name: file.name,
         size: file.size,
         type: file.type,
@@ -311,7 +310,7 @@ export async function signWithBlockusign(fileId) {
         lastModified: file.lastModified,
         lastModifiedDate: file.lastModifiedDate,
         publicVaultFile: file.publicVaultFile,
-        id: file.id, 
+        id: file.id,
         fileType: "vault"
     }
     let index = await files.map((x) => {return x.id }).indexOf(window.location.href.split('files/')[1]);
@@ -322,8 +321,8 @@ export async function signWithBlockusign(fileId) {
       console.log("Error doc index")
     }
     let fileIndexParams = {
-        fileName: 'uploads.json', 
-        encrypt: true, 
+        fileName: 'uploads.json',
+        encrypt: true,
         body: JSON.stringify(getGlobal().files)
     }
     const postedIndex = await postData(fileIndexParams);
@@ -340,52 +339,52 @@ export async function signWithBlockusign(fileId) {
     const content = await getGlobal().singleFileContent;
     const id = uuid();
     let singleModel = {
-      id: id, 
+      id: id,
       content,
-      fileType: "documents", 
-      lastUpdate: Date.now(), 
-      updated: getMonthDayYear(), 
+      fileType: "documents",
+      lastUpdate: Date.now(),
+      updated: getMonthDayYear(),
       readOnly: true,
       rtc: false,
-      sharedWith: [], 
+      sharedWith: [],
       singleDocIsPublic: false,
-      singleDocTags: [], 
-      teamDoc: false, 
+      singleDocTags: [],
+      teamDoc: false,
       versions: [],
-      title: singleFile.name, 
+      title: singleFile.name,
       compressed: true
   }
     let fileName = `/documents/${id}.json`;
     let docParams = {
-        fileName, 
-        body: JSON.stringify(singleModel), 
+        fileName,
+        body: JSON.stringify(singleModel),
         encrypt: true
     }
     const updatedDoc = await postData(docParams);
     console.log(updatedDoc);
-    
+
     //Now we update the index file;
     let docs = await getGlobal().documents;
     let docObject = {
-      id: id, 
-      fileType: "documents", 
-      lastUpdate: Date.now(), 
-      updated: getMonthDayYear(), 
+      id: id,
+      fileType: "documents",
+      lastUpdate: Date.now(),
+      updated: getMonthDayYear(),
       readOnly: true,
       rtc: false,
-      sharedWith: [], 
+      sharedWith: [],
       singleDocIsPublic: false,
-      singleDocTags: [], 
-      teamDoc: false, 
+      singleDocTags: [],
+      teamDoc: false,
       versions: [],
       title: singleFile.name
     }
 
     await setGlobal({ documents: [...docs, docObject], filteredDocs: [...getGlobal().filteredDocs, docObject]})
-    
+
     let indexParams = {
-      fileName: 'documentscollection.json', 
-      body: JSON.stringify(getGlobal().documents), 
+      fileName: 'documentscollection.json',
+      body: JSON.stringify(getGlobal().documents),
       encrypt: true
     }
 
@@ -409,61 +408,59 @@ export async function signWithBlockusign(fileId) {
       decrypt: true
     }
     const fetchedKeys = await fetchData(teamKeyParams);
-  
+
     const file = {
       id: fileId,
-      team: data.teamId, 
+      team: data.teamId,
       orgId: proOrgInfo.orgId,
-      name: getGlobal().name, 
+      name: getGlobal().name,
       file: getGlobal().singleFile,
       currentHostBucket: userSession.loadUserData().username
     }
     const encryptedTeamFile = userSession.encryptContent(JSON.stringify(file), {publicKey: JSON.parse(fetchedKeys).public})
-   
+
     const teamFile = {
-      fileName: `teamFiles/${data.teamId}/${fileId}.json`, 
+      fileName: `teamFiles/${data.teamId}/${fileId}.json`,
       encrypt: false,
       body: JSON.stringify(encryptedTeamFile)
     }
     const postedTeamFile = await postData(teamFile);
     console.log(postedTeamFile);
-  
+
     let singleFile = getGlobal().singleFile;
     singleFile["teamFile"] = true;
     await setGlobal({ singleFile });
     await saveFile();
-  
+
     const privateKey = userSession.loadUserData().appPrivateKey;
-  
+
     const syncedFile = {
       id: fileId,
-      name: userSession.encryptContent(getGlobal().name, {publicKey: JSON.parse(fetchedKeys).public}), 
+      name: userSession.encryptContent(getGlobal().name, {publicKey: JSON.parse(fetchedKeys).public}),
       teamName: userSession.encryptContent(data.teamName, {publicKey: JSON.parse(fetchedKeys).public}),
       orgId: proOrgInfo.orgId,
       teamId: data.teamId,
       lastUpdated: getMonthDayYear(),
-      timestamp: Date.now(), 
+      timestamp: Date.now(),
       currentHostBucket: userSession.encryptContent(userSession.loadUserData().username, {publicKey: JSON.parse(fetchedKeys).public}),
       pubKey: getPublicKeyFromPrivate(privateKey)
     }
-    
-    let serverUrl;
+
       const tokenData = {
-          profile: userSession.loadUserData().profile, 
-          username: userSession.loadUserData().username, 
+          profile: userSession.loadUserData().profile,
+          username: userSession.loadUserData().username,
           pubKey: getPublicKeyFromPrivate(privateKey)
       }
       const bearer = blockstack.signProfileToken(tokenData, userSession.loadUserData().appPrivateKey);
-      
-      environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
+
       const headerObj = {
           headers: {
-              'Access-Control-Allow-Origin': '*', 
-              'Content-Type': 'application/json', 
+              'Access-Control-Allow-Origin': '*',
+              'Content-Type': 'application/json',
               'Authorization': bearer
-          }, 
+          },
       }
-      axios.post(`${serverUrl}/account/organization/${proOrgInfo.orgId}/files`, JSON.stringify(syncedFile), headerObj)
+      axios.post(`/account/organization/${proOrgInfo.orgId}/files`, JSON.stringify(syncedFile), headerObj)
           .then(async (res) => {
               console.log(res.data)
               if(res.data.success === false) {
@@ -481,4 +478,3 @@ export async function signWithBlockusign(fileId) {
               }
           })
   }
-

--- a/src/components/files/helpers/teamFiles.js
+++ b/src/components/files/helpers/teamFiles.js
@@ -3,7 +3,6 @@ import { getGlobal } from 'reactn';
 import { ToastsStore} from 'react-toasts';
 import { getPublicKeyFromPrivate } from 'blockstack/lib/keys';
 import { loadData } from '../../shared/helpers/accountContext';
-const environment = window.location.origin;
 const blockstack = require('blockstack');
 
 export function deleteTeamFile(data) {
@@ -11,24 +10,20 @@ export function deleteTeamFile(data) {
 
     const privateKey = userSession.loadUserData().appPrivateKey;
     const pubKey = getPublicKeyFromPrivate(privateKey);
-
-    let serverUrl;
     const tokenData = {
-        profile: userSession.loadUserData().profile, 
-        username: userSession.loadUserData().username, 
+        profile: userSession.loadUserData().profile,
+        username: userSession.loadUserData().username,
         pubKey
     }
     const bearer = blockstack.signProfileToken(tokenData, userSession.loadUserData().appPrivateKey);
-
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
-    axios.delete(`${serverUrl}/account/organization/${proOrgInfo.orgId}/teams/${data.teamId}/files/${data.docId}?pubKey=${pubKey}`, headerObj)
+    axios.delete(`/account/organization/${proOrgInfo.orgId}/teams/${data.teamId}/files/${data.docId}?pubKey=${pubKey}`, headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {

--- a/src/components/forms/helpers/publicForm.js
+++ b/src/components/forms/helpers/publicForm.js
@@ -3,7 +3,6 @@ import {setGlobal, getGlobal} from 'reactn';
 import { getMonthDayYear } from '../../shared/helpers/getMonthDayYear';
 import { ToastsStore} from 'react-toasts';
 const uuid = require('uuidv4');
-const environment = window.location.origin;
 const blockstack = require('blockstack');
 let host;
 
@@ -17,16 +16,15 @@ export async function loadPublicForm() {
         //console.log("team form");
         const formId = window.location.href.split('forms/')[1].split('/')[1];
         const orgId = window.location.href.split('forms/')[1].split('/')[0];
-        const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
         const headerObj = {
             headers: {
-                'Access-Control-Allow-Origin': '*', 
+                'Access-Control-Allow-Origin': '*',
                 'Content-Type': 'application/json'
-            }, 
+            },
         }
         //console.log(formId);
         //console.log(`${baseUrl}/public/organization/${orgId}/forms/${formId}`);
-        axios.get(`${baseUrl}/public/organization/${orgId}/forms/${formId}`, headerObj)
+        axios.get(`/public/organization/${orgId}/forms/${formId}`, headerObj)
             .then(async (res) => {
                 console.log(res);
                 if(res.data.data) {
@@ -50,7 +48,7 @@ export async function loadFromHost(host) {
     }
     // const options = { username: host, zoneFileLookupURL: "https://core.blockstack.org/v1/names", decrypt: false}
     // let params = {
-    //     fileName: `public/forms/${formId}.json`, 
+    //     fileName: `public/forms/${formId}.json`,
     //     options
     // }
     // let fetchedForm = await fetchData(params);
@@ -87,22 +85,20 @@ export async function postForm(responses) {
         const orgId = window.location.href.split('forms/')[1].split('/')[0];
         const thisResponse = {
             id: uuid(),
-            responses, 
+            responses,
             dateSubmitted: getMonthDayYear(),
-            timestamp: Date.now(), 
+            timestamp: Date.now(),
             title: publicForm.title,
-            formId, 
+            formId,
             orgId
         }
-        let serverUrl;
-        environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
         const headerObj = {
             headers: {
-                'Access-Control-Allow-Origin': '*', 
+                'Access-Control-Allow-Origin': '*',
                 'Content-Type': 'application/json'
-            }, 
+            },
         }
-        axios.post(`${serverUrl}/public/organization/${orgId}/forms/${formId}/user/${user}`, JSON.stringify(thisResponse), headerObj)
+        axios.post(`/public/organization/${orgId}/forms/${formId}/user/${user}`, JSON.stringify(thisResponse), headerObj)
             .then(async (res) => {
                 console.log(res.data)
                 if(res.data.success === false) {
@@ -119,19 +115,17 @@ export async function postForm(responses) {
         const orgId = window.location.href.split('forms/')[1].split('/')[0];
         const thisResponse = {
             id: uuid(),
-            responses, 
+            responses,
             dateSubmitted: getMonthDayYear(),
             timestamp: Date.now()
         }
-        let serverUrl;
-        environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
         const headerObj = {
             headers: {
-                'Access-Control-Allow-Origin': '*', 
+                'Access-Control-Allow-Origin': '*',
                 'Content-Type': 'application/json'
-            }, 
+            },
         }
-        axios.post(`${serverUrl}/public/organization/${orgId}/forms/${formId}`, JSON.stringify(thisResponse), headerObj)
+        axios.post(`/public/organization/${orgId}/forms/${formId}`, JSON.stringify(thisResponse), headerObj)
             .then(async (res) => {
                 console.log(res.data)
                 if(res.data.success === false) {

--- a/src/components/forms/helpers/singleForm.js
+++ b/src/components/forms/helpers/singleForm.js
@@ -6,7 +6,6 @@ import { postData } from '../../shared/helpers/post';
 import { getPublicKeyFromPrivate } from 'blockstack/lib/keys';
 import update from 'immutability-helper';
 import axios from 'axios';
-const environment = window.location.origin;
 const blockstack = require('blockstack');
 var timer = null;
 
@@ -26,38 +25,37 @@ export async function loadForm(id) {
         fetchedKeys = await fetchData(teamKeyParams);
         console.log(fetchedKeys);
         setGlobal({ teamKeys: fetchedKeys });
-        const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
         const data = {
-            profile: userSession.loadUserData().profile, 
+            profile: userSession.loadUserData().profile,
             username: userSession.loadUserData().username
         }
         const pubKey = getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
         const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
         const headerObj = {
             headers: {
-                'Access-Control-Allow-Origin': '*', 
-                'Content-Type': 'application/json', 
+                'Access-Control-Allow-Origin': '*',
+                'Content-Type': 'application/json',
                 'Authorization': bearer
-            }, 
+            },
         }
 
-        axios.get(`${baseUrl}/public/organization/${getGlobal().proOrgInfo.orgId}/forms/${id}?pubKey=${pubKey}`, headerObj)
+        axios.get(`/public/organization/${getGlobal().proOrgInfo.orgId}/forms/${id}?pubKey=${pubKey}`, headerObj)
             .then(async (res) => {
-                
+
                 if(res.data.data) {
                     const host = res.data.data.currentHostBucket;
                     const options = { username: host, zoneFileLookupURL: "https://core.blockstack.org/v1/names", decrypt: false}
                     let params = {
-                        fileName: `forms/${id}.json`, 
+                        fileName: `forms/${id}.json`,
                         options
                     }
-                
+
                     let teamForm = await fetchData(params);
                     let decryptedForm = JSON.parse(userSession.decryptContent(teamForm, {privateKey: JSON.parse(fetchedKeys).private}));
-                    
+
                     await setGlobal({ singleForm: decryptedForm, formLoading: false });
                     //finally we need to fetch the responses
-                    axios.get(`${baseUrl}/account/organization/${getGlobal().proOrgInfo.orgId}/forms/${id}?pubKey=${pubKey}`, headerObj)
+                    axios.get(`/account/organization/${getGlobal().proOrgInfo.orgId}/forms/${id}?pubKey=${pubKey}`, headerObj)
                         .then(async (res) => {
                             console.log(res);
                             if(res.data.data) {
@@ -79,29 +77,28 @@ export async function loadForm(id) {
             }).catch(err => console.log(err));
     } else {
         const formParams = {
-            fileName: `forms/${id}.json`, 
+            fileName: `forms/${id}.json`,
             decrypt: true
         }
         const form = await fetchData(formParams);
         if(JSON.parse(form)) {
             await setGlobal({ singleForm: JSON.parse(form), formLoading: false});
-            
+
             if(teamForm) {
-                const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
                 const data = {
-                    profile: userSession.loadUserData().profile, 
+                    profile: userSession.loadUserData().profile,
                     username: userSession.loadUserData().username
                 }
                 const pubKey = getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
                 const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
                 const headerObj = {
                     headers: {
-                        'Access-Control-Allow-Origin': '*', 
-                        'Content-Type': 'application/json', 
+                        'Access-Control-Allow-Origin': '*',
+                        'Content-Type': 'application/json',
                         'Authorization': bearer
-                    }, 
+                    },
                 }
-                axios.get(`${baseUrl}/public/organization/${getGlobal().proOrgInfo.orgId}/forms/${id}?pubKey=${pubKey}`, headerObj)
+                axios.get(`/public/organization/${getGlobal().proOrgInfo.orgId}/forms/${id}?pubKey=${pubKey}`, headerObj)
                     .then(async (res) => {
                         console.log(res);
                         if(res.data.data) {
@@ -117,21 +114,20 @@ export async function loadForm(id) {
                         }
                     }).catch(err => console.log(err));
             } else {
-                const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
                 const data = {
-                    profile: userSession.loadUserData().profile, 
+                    profile: userSession.loadUserData().profile,
                     username: userSession.loadUserData().username
                 }
                 const pubKey = getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
                 const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
                 const headerObj = {
                     headers: {
-                        'Access-Control-Allow-Origin': '*', 
-                        'Content-Type': 'application/json', 
+                        'Access-Control-Allow-Origin': '*',
+                        'Content-Type': 'application/json',
                         'Authorization': bearer
-                    }, 
+                    },
                 }
-                axios.get(`${baseUrl}/public/forms/${id}/user/${userSession.loadUserData().username}?pubKey=${pubKey}`, headerObj)
+                axios.get(`/public/forms/${id}/user/${userSession.loadUserData().username}?pubKey=${pubKey}`, headerObj)
                 .then(async (res) => {
                     if(res.data.data) {
                         setGlobal({ formResponses: res.data.data});
@@ -163,7 +159,7 @@ export async function postNewForm(id, fetchedKeys) {
         if(teamForm) {
             teamId = window.location.href.split('team/')[1].split('/')[0];
         }
-        
+
         setGlobal({ formLoading: false });
         //Need to create the form since it doesn't exist yet
         const formObject = {
@@ -172,11 +168,11 @@ export async function postNewForm(id, fetchedKeys) {
             title: "Untitled",
             created: getMonthDayYear(),
             lastUpdated: Date.now(),
-            questions: [], 
+            questions: [],
             teamForm: teamForm ? true : false,
             teamName: teamForm ? getGlobal().teamName : "",
             teamId: teamForm ? getGlobal().teamId : "",
-            teams: [], 
+            teams: [],
             responses: []
         }
         setGlobal({ singleForm: formObject });
@@ -184,23 +180,23 @@ export async function postNewForm(id, fetchedKeys) {
             //Don't add to index
             const encryptedFormObject = userSession.encryptContent(JSON.stringify(formObject), {publicKey: JSON.parse(fetchedKeys).public})
             const newFormParams = {
-                fileName: `forms/${formObject.id}.json`, 
-                encrypt: false, 
+                fileName: `forms/${formObject.id}.json`,
+                encrypt: false,
                 body: encryptedFormObject
             }
             const newForm = await postData(newFormParams);
             console.log(newForm);
             const data = {
-                fromSave: true, 
-                teamId: teamId, 
-                teamName: teamName, 
+                fromSave: true,
+                teamId: teamId,
+                teamName: teamName,
                 initialShare: true
             }
             shareWithTeam(data);
         } else {
             const newFormParams = {
-                fileName: `forms/${formObject.id}.json`, 
-                encrypt: true, 
+                fileName: `forms/${formObject.id}.json`,
+                encrypt: true,
                 body: JSON.stringify(formObject)
             }
             const newForm = await postData(newFormParams);
@@ -233,11 +229,11 @@ export async function saveForm(teamShare) {
         title: singleForm.title,
         created: singleForm.created,
         lastUpdated: Date.now(),
-        questions: singleForm.questions, 
-        teamForm: singleForm.teamForm, 
-        teams: singleForm.teams, 
+        questions: singleForm.questions,
+        teamForm: singleForm.teamForm,
+        teams: singleForm.teams,
         teamName: singleForm.teamName || "",
-        teamId: singleForm.teamId || "", 
+        teamId: singleForm.teamId || "",
         responses: singleForm.responses || []
     }
     await setGlobal({ singleForm: formObject });
@@ -249,20 +245,20 @@ export async function saveForm(teamShare) {
         const thisTeam = teams.filter(a => a.id === teamId)[0];
 
         newFormParams = {
-            fileName: `forms/${formObject.id}.json`, 
-            encrypt: false, 
+            fileName: `forms/${formObject.id}.json`,
+            encrypt: false,
             body: encryptedTeamForm
         }
         const data = {
-            fromSave: true, 
+            fromSave: true,
             teamName: thisTeam.name,
             teamId: teamId
           }
           shareWithTeam(data);
     } else {
         newFormParams = {
-            fileName: `forms/${formObject.id}.json`, 
-            encrypt: true, 
+            fileName: `forms/${formObject.id}.json`,
+            encrypt: true,
             body: JSON.stringify(formObject)
         }
         let forms = getGlobal().forms;
@@ -285,7 +281,7 @@ export async function saveForm(teamShare) {
     }
 
     const newForm = await postData(newFormParams);
-    
+
     ToastsStore.success(`Form saved`);
     console.log(newForm);
 }
@@ -310,7 +306,7 @@ export function handleFormTitle(e) {
     title = e.target.value;
     singleForm["title"] = title;
     setGlobal({ singleForm });
-    clearTimeout(timer); 
+    clearTimeout(timer);
     timer = setTimeout(() => {
         saveForm();
         setGlobal({ formTitleSaved: true });
@@ -332,16 +328,16 @@ export async function publicForm(type) {
         title: singleForm.title,
         created: singleForm.created,
         lastUpdated: Date.now(),
-        questions: singleForm.questions, 
+        questions: singleForm.questions,
         teamForm: singleForm.teamForm,
-        teams: singleForm.teams, 
+        teams: singleForm.teams,
         responses: getGlobal().formResponses
     }
     console.log(formObject);
     setGlobal({ singleForm: formObject });
     const newFormParams = {
-        fileName: `public/forms/${formObject.id}.json`, 
-        encrypt: false, 
+        fileName: `public/forms/${formObject.id}.json`,
+        encrypt: false,
         body: JSON.stringify(formObject)
     }
     const newPublicForm = await postData(newFormParams);
@@ -356,7 +352,7 @@ export async function publicForm(type) {
         }
         shareWithTeam(teamInfo);
     }
-   
+
     if(type === 'link') {
         setGlobal({ formLinkModalOpen: true })
     } else {
@@ -386,16 +382,16 @@ export async function shareWithTeam(data) {
     let singleForm = getGlobal().singleForm;
     const form = {
       id: singleForm.id,
-      team: data.teamId, 
+      team: data.teamId,
       orgId: proOrgInfo.orgId,
       title: singleForm.title,
       responses: singleForm.responses || getGlobal().formResponses,
       currentHostBucket: userSession.loadUserData().username
     }
     const encryptedTeamForm = userSession.encryptContent(JSON.stringify(form), {publicKey: JSON.parse(fetchedKeys).public})
-   
+
     const teamForm = {
-      fileName: `teamForms/${data.teamId}/${singleForm.id}.json`, 
+      fileName: `teamForms/${data.teamId}/${singleForm.id}.json`,
       encrypt: false,
       body: JSON.stringify(encryptedTeamForm)
     }
@@ -411,39 +407,35 @@ export async function shareWithTeam(data) {
     } else {
       await saveForm(false);
     }
-  
+
     const privateKey = userSession.loadUserData().appPrivateKey;
-  
+
     const syncedForm = {
       id: singleForm.id,
-      title: userSession.encryptContent(singleForm.title, {publicKey: JSON.parse(fetchedKeys).public}), 
+      title: userSession.encryptContent(singleForm.title, {publicKey: JSON.parse(fetchedKeys).public}),
       teamName: data.teamName ? userSession.encryptContent(data.teamName, {publicKey: JSON.parse(fetchedKeys).public}) : "",
       orgId: proOrgInfo.orgId,
       teamId: data.teamId,
       lastUpdated: getMonthDayYear(),
-      timestamp: Date.now(), 
+      timestamp: Date.now(),
       responses: singleForm.responses || getGlobal().formResponses,
       currentHostBucket: userSession.loadUserData().username,
       pubKey: getPublicKeyFromPrivate(privateKey)
     }
-    
-    let serverUrl;
       const tokenData = {
-          profile: userSession.loadUserData().profile, 
-          username: userSession.loadUserData().username, 
+          profile: userSession.loadUserData().profile,
+          username: userSession.loadUserData().username,
           pubKey: getPublicKeyFromPrivate(privateKey)
       }
       const bearer = blockstack.signProfileToken(tokenData, userSession.loadUserData().appPrivateKey);
-      
-      environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
       const headerObj = {
           headers: {
-              'Access-Control-Allow-Origin': '*', 
-              'Content-Type': 'application/json', 
+              'Access-Control-Allow-Origin': '*',
+              'Content-Type': 'application/json',
               'Authorization': bearer
-          }, 
+          },
       }
-      axios.post(`${serverUrl}/account/organization/${proOrgInfo.orgId}/forms`, JSON.stringify(syncedForm), headerObj)
+      axios.post(`/account/organization/${proOrgInfo.orgId}/forms`, JSON.stringify(syncedForm), headerObj)
           .then(async (res) => {
               console.log(res.data)
               if(res.data.success === false) {

--- a/src/components/pro/helpers/account.js
+++ b/src/components/pro/helpers/account.js
@@ -5,7 +5,6 @@ import { ToastsStore} from 'react-toasts';
 import { fetchData } from '../../shared/helpers/fetch';
 import { getPublicKeyFromPrivate } from 'blockstack/lib/keys';
 const blockstack = require("blockstack");
-const environment = window.location.origin;
 
 export async function handleProCheck() {
     if(window.location.href.includes('invite/accept')) {
@@ -50,35 +49,34 @@ export async function handleProCheck() {
 
 export async function checkPro() {
     const accountParams = {
-        fileName: "account.json", 
+        fileName: "account.json",
         decrypt: true
     }
     const account = await fetchData(accountParams);
     if(account) {
         const orgId = JSON.parse(account).orgId;
         const { userSession } = getGlobal();
-        const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
         const username = userSession.loadUserData().username;
         const pubKey = blockstack.getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
         const data = {
-            profile: userSession.loadUserData().profile, 
+            profile: userSession.loadUserData().profile,
             username: userSession.loadUserData().username
         }
         const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
         const headerObj = {
             headers: {
-                'Access-Control-Allow-Origin': '*', 
-                'Content-Type': 'application/json', 
+                'Access-Control-Allow-Origin': '*',
+                'Content-Type': 'application/json',
                 'Authorization': bearer
-            }, 
+            },
         }
-        return axios.get(`${baseUrl}/account/org/${orgId}/user/${username}?pubKey=${pubKey}`, headerObj)
+        return axios.get(`/account/org/${orgId}/user/${username}?pubKey=${pubKey}`, headerObj)
             .then(async (res) => {
                 if(res.data.data) {
                     return res.data.data;
                 } else {
                     return "User not found";
-    
+
                 }
             }).catch(err => console.log(err));
     } else {
@@ -112,30 +110,29 @@ export async function saveOrgDetails() {
     orgInfo["orgName"] = getGlobal().orgName;
     setGlobal({ proOrgInfo: orgInfo });
     let orgParams = {
-        fileName: "account.json", 
-        encrypt: true, 
+        fileName: "account.json",
+        encrypt: true,
         body: JSON.stringify(orgInfo)
     }
     let postOrgInfo = await postData(orgParams);
     console.log(postOrgInfo);
     //Then update the DB
     const data = {
-        profile: userSession.loadUserData().profile, 
+        profile: userSession.loadUserData().profile,
         username: userSession.loadUserData().username
     }
     const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
         },
     }
-    let serverUrl = window.location.href.includes("local") ? "http://localhost:5000" : "https://socket.graphitedocs.com";
     const orgId = getGlobal().proOrgInfo.orgId;
-    const url = `${serverUrl}/account/org/name/${orgId}`;
+    const url = `/account/org/name/${orgId}`;
     const body = {
-        orgName: getGlobal().orgName, 
+        orgName: getGlobal().orgName,
         orgId: getGlobal().proOrgInfo.orgId,
         pubKey
     }
@@ -157,23 +154,21 @@ export async function deleteFromOrg(data) {
     const privateKey = userSession.loadUserData().appPrivateKey;
     const pubKey = getPublicKeyFromPrivate(privateKey);
 
-    let serverUrl;
     const tokenData = {
-        profile: userSession.loadUserData().profile, 
-        username: userSession.loadUserData().username, 
+        profile: userSession.loadUserData().profile,
+        username: userSession.loadUserData().username,
         pubKey
     }
     const bearer = blockstack.signProfileToken(tokenData, userSession.loadUserData().appPrivateKey);
 
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
-    axios.delete(`${serverUrl}/account/organization/${proOrgInfo.orgId}/users/${data.id}?pubKey=${pubKey}`, headerObj)
+    axios.delete(`/account/organization/${proOrgInfo.orgId}/users/${data.id}?pubKey=${pubKey}`, headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {

--- a/src/components/pro/helpers/account.js
+++ b/src/components/pro/helpers/account.js
@@ -53,6 +53,7 @@ export async function checkPro() {
         decrypt: true
     }
     const account = await fetchData(accountParams);
+    console.log(account);
     if(account) {
         const orgId = JSON.parse(account).orgId;
         const { userSession } = getGlobal();

--- a/src/components/pro/helpers/team.js
+++ b/src/components/pro/helpers/team.js
@@ -8,7 +8,6 @@ import { generateInviteJWT } from './invites';
 import { fetchData } from '../../shared/helpers/fetch';
 const blockstack = require('blockstack');
 const uuid = require('uuidv4');
-const environment = window.location.origin;
 
 export async function fetchTeamKey() {
     const { userSession } = getGlobal();
@@ -37,14 +36,14 @@ export async function saveNewTeam() {
         team: {
             name: getGlobal().newTeamName,
             id: teamId,
-            pubKey: publicKey, 
+            pubKey: publicKey,
             users: [
                 {
                     id: userInfo.id,
                     username: userSession.loadUserData().username,
                     role: checkRole === "Admin" ? "Admin" : "Manager",
-                    email: userInfo.email, 
-                    name: userInfo.name 
+                    email: userInfo.email,
+                    name: userInfo.name
                 }
             ]
         }
@@ -56,29 +55,25 @@ export async function saveNewTeam() {
 
     const teamKeyParams = {
         fileName: `user/${userSession.loadUserData().username.split('.').join('_')}/team/${teamObj.team.id}/key.json`,
-        encrypt: true, 
+        encrypt: true,
         body: JSON.stringify(teamKey)
     }
     const postedTeamKey = await postData(teamKeyParams);
     console.log(postedTeamKey);
-
-    let serverUrl;
     const data = {
-        profile: userSession.loadUserData().profile, 
-        username: userSession.loadUserData().username, 
+        profile: userSession.loadUserData().profile,
+        username: userSession.loadUserData().username,
         pubKey: getPublicKeyFromPrivate(privateKey)
     }
     const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
-    
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
-    axios.post(`${serverUrl}/account/org/team`, JSON.stringify(teamObj), headerObj)
+    axios.post(`/account/org/team`, JSON.stringify(teamObj), headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {
@@ -101,8 +96,8 @@ export async function saveNewTeammate(data) {
         id: userId,
         username: null,
         role: data.role,
-        email: data.email, 
-        name: data.name, 
+        email: data.email,
+        name: data.name,
         invitePending: true
     }
 
@@ -115,8 +110,8 @@ export async function saveNewTeammate(data) {
     orgInfo.users.push(updatedUserObj);
     await setGlobal({ proOrgInfo: orgInfo });
     const accountParams = {
-        fileName: "account.json", 
-        encrypt: true, 
+        fileName: "account.json",
+        encrypt: true,
         body: JSON.stringify(getGlobal().proOrgInfo)
     }
     const updatedAccount = await postData(accountParams);
@@ -125,23 +120,20 @@ export async function saveNewTeammate(data) {
     userObj["selectedTeam"] = data.selectedTeam;
     userObj["pubKey"] = getPublicKeyFromPrivate(privateKey);
     userObj["orgId"] = proOrgInfo.orgId;
-    let serverUrl;
     const jwtData = {
-        profile: userSession.loadUserData().profile, 
-        username: userSession.loadUserData().username, 
+        profile: userSession.loadUserData().profile,
+        username: userSession.loadUserData().username,
         pubKey: getPublicKeyFromPrivate(privateKey)
     }
     const bearer = blockstack.signProfileToken(jwtData, userSession.loadUserData().appPrivateKey);
-    
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
-    axios.post(`${serverUrl}/account/user?updateTeam=${true}`, JSON.stringify(userObj), headerObj)
+    axios.post(`/account/user?updateTeam=${true}`, JSON.stringify(userObj), headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {
@@ -166,23 +158,20 @@ export async function deleteUser(data) {
     const privateKey = userSession.loadUserData().appPrivateKey;
     const pubKey = getPublicKeyFromPrivate(privateKey);
 
-    let serverUrl;
     const tokenData = {
-        profile: userSession.loadUserData().profile, 
-        username: userSession.loadUserData().username, 
+        profile: userSession.loadUserData().profile,
+        username: userSession.loadUserData().username,
         pubKey
     }
     const bearer = blockstack.signProfileToken(tokenData, userSession.loadUserData().appPrivateKey);
-
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
-    axios.delete(`${serverUrl}/account/organization/${proOrgInfo.orgId}/teams/${data.team}/users/${data.user.id}?pubKey=${pubKey}`, headerObj)
+    axios.delete(`/account/organization/${proOrgInfo.orgId}/teams/${data.team}/users/${data.user.id}?pubKey=${pubKey}`, headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {

--- a/src/components/pro/helpers/trialSignUps.js
+++ b/src/components/pro/helpers/trialSignUps.js
@@ -6,8 +6,6 @@ import { postData } from '../../shared/helpers/post';
 const blockstack = require('blockstack');
 const uuid = require("uuidv4");
 
-const environment = window.location.origin;
-
 export async function startTrial() {
     const { userSession } = getGlobal();
     const privateKey = makeECPrivateKey();
@@ -18,40 +16,38 @@ export async function startTrial() {
     const trialObject = {
         orgId: uuid(),
         userId: uuid(),
-        name, 
-        organization, 
-        email, 
-        blockstackId: getGlobal().userSession.loadUserData().username, 
+        name,
+        organization,
+        email,
+        blockstackId: getGlobal().userSession.loadUserData().username,
         pubKey: blockstack.getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey),
         teamPubKey: publicKey
     }
 
     let trialParams = {
-        fileName: "account.json", 
+        fileName: "account.json",
         encrypt: true,
         body: JSON.stringify(trialObject)
     }
 
     let postTrial = await postData(trialParams);
     console.log(postTrial);
-    
-    let serverUrl;
+
     const data = {
-        profile: userSession.loadUserData().profile, 
-        username: userSession.loadUserData().username, 
+        profile: userSession.loadUserData().profile,
+        username: userSession.loadUserData().username,
         pubKey: getPublicKeyFromPrivate(privateKey)
     }
     const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
-    
-    environment.includes('local') ? serverUrl = 'http://localhost:5000' : serverUrl = 'https://socket.graphitedocs.com';
+
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
-    axios.post(`${serverUrl}/account/org`, JSON.stringify(trialObject), headerObj)
+    axios.post(`/account/org`, JSON.stringify(trialObject), headerObj)
         .then(async (res) => {
             console.log(res.data)
             if(res.data.success === false) {
@@ -64,8 +60,8 @@ export async function startTrial() {
                 //Now we need to save the team public key to Gaia.
 
                 const teamKeyParams = {
-                    fileName: `admins/key/${privateKey}`, 
-                    encrypt: true, 
+                    fileName: `admins/key/${privateKey}`,
+                    encrypt: true,
                     body: JSON.stringify(privateKey)
                 }
                 const postedKey = await postData(teamKeyParams);

--- a/src/components/pro/views/API/ApiDocs.js
+++ b/src/components/pro/views/API/ApiDocs.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'reactn';
 import SwaggerUI from "swagger-ui-react"
+import axios from 'axios';
 import "swagger-ui-react/swagger-ui.css"
 
 class APIDocs extends Component {
   render() {
       return (
         <div>
-            <SwaggerUI url="http://localhost:5000/api-spec" />
+            <SwaggerUI url={`${axios.default.baseURL}/api-spec`} />
         </div>
        );
   }

--- a/src/components/shared/helpers/accountContext.js
+++ b/src/components/shared/helpers/accountContext.js
@@ -11,13 +11,13 @@ export async function loadData(params) {
     } else {
         setGlobal({ loading: true })
     }
-    
+
     const docsParams = {
-        fileName: 'documentscollection.json', 
+        fileName: 'documentscollection.json',
         decrypt: true
     }
     const contactsParams = {
-        fileName: 'contact.json', 
+        fileName: 'contact.json',
         decrypt: true
     }
     const filesParams = {
@@ -26,7 +26,7 @@ export async function loadData(params) {
     }
 
     const keyParams = {
-        fileName: "key.json", 
+        fileName: "key.json",
         decrypt: false
     }
 
@@ -55,7 +55,7 @@ export async function loadData(params) {
     } else {
         oldContactsFile = true;
     }
-    
+
     let files = await fetchData(filesParams);
 
     const formsParams = {
@@ -66,7 +66,7 @@ export async function loadData(params) {
     let forms = await fetchData(formsParams);
 
     setGlobal({
-        documents: JSON.parse(docs) ? oldFile === true ? JSON.parse(docs).value : JSON.parse(docs) : [], 
+        documents: JSON.parse(docs) ? oldFile === true ? JSON.parse(docs).value : JSON.parse(docs) : [],
         filteredDocs: JSON.parse(docs) ? oldFile === true ? JSON.parse(docs).value : JSON.parse(docs) : [],
         contacts: JSON.parse(contacts) ? oldContactsFile === true ? JSON.parse(contacts).contacts : JSON.parse(contacts) : [],
         filteredContacts: JSON.parse(contacts) ? oldContactsFile === true ? JSON.parse(contacts).contacts : JSON.parse(contacts) : [],
@@ -91,8 +91,8 @@ export async function saveKey() {
     const { userSession } = getGlobal();
     const pubKey = getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
     const keyParams = {
-        fileName: "key.json", 
-        encrypt: false, 
+        fileName: "key.json",
+        encrypt: false,
         body: JSON.stringify(pubKey)
     }
     const postedKey = await postData(keyParams);
@@ -112,23 +112,22 @@ export async function fetchTeamDocs() {
         return myTeams;
     });
 
-    const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
     const data = {
-        profile: userSession.loadUserData().profile, 
+        profile: userSession.loadUserData().profile,
         username: userSession.loadUserData().username
     }
     const pubKey = getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
     const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
 
     for(const team of myTeams) {
-        await axios.get(`${baseUrl}/account/organization/${orgId}/documents/${team.id}?pubKey=${pubKey}`, headerObj)
+        await axios.get(`/account/organization/${orgId}/documents/${team.id}?pubKey=${pubKey}`, headerObj)
         .then(async (res) => {
             if(res.data.data) {
                 const docs = res.data.data;
@@ -138,14 +137,14 @@ export async function fetchTeamDocs() {
                     decrypt: true,
                 }
                 const fetchedKeys = await fetchData(teamKeyParams);
-                
+
                 // const thisDoc = userSession.decryptContent(JSON.parse(res.data.data), {privateKey: privateKey});
                 asyncForEach(docs, (doc) => {
                     let thisDoc = doc;
                     thisDoc.currentHostBucket = userSession.decryptContent(thisDoc.currentHostBucket, {privateKey: JSON.parse(fetchedKeys).private});
                     thisDoc.teamName = userSession.decryptContent(thisDoc.teamName, {privateKey: JSON.parse(fetchedKeys).private});
                     thisDoc.title = userSession.decryptContent(thisDoc.title, {privateKey: JSON.parse(fetchedKeys).private});
-                
+
                     teamDocs.push(thisDoc);
                 })
             } else {
@@ -170,23 +169,22 @@ export async function fetchTeamFiles() {
         return myTeams;
     });
 
-    const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
     const data = {
-        profile: userSession.loadUserData().profile, 
+        profile: userSession.loadUserData().profile,
         username: userSession.loadUserData().username
     }
     const pubKey = getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
     const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
 
     for(const team of myTeams) {
-        await axios.get(`${baseUrl}/account/organization/${orgId}/files/${team.id}?pubKey=${pubKey}`, headerObj)
+        await axios.get(`/account/organization/${orgId}/files/${team.id}?pubKey=${pubKey}`, headerObj)
         .then(async (res) => {
             if(res.data.data) {
                 const files = res.data.data;
@@ -196,14 +194,14 @@ export async function fetchTeamFiles() {
                     decrypt: true,
                 }
                 const fetchedKeys = await fetchData(teamKeyParams);
-                
+
                 // const thisDoc = userSession.decryptContent(JSON.parse(res.data.data), {privateKey: privateKey});
                 asyncForEach(files, (file) => {
                     let thisFile = file;
                     thisFile.currentHostBucket = userSession.decryptContent(thisFile.currentHostBucket, {privateKey: JSON.parse(fetchedKeys).private});
                     thisFile.teamName = userSession.decryptContent(thisFile.teamName, {privateKey: JSON.parse(fetchedKeys).private});
                     thisFile.name = userSession.decryptContent(thisFile.name, {privateKey: JSON.parse(fetchedKeys).private});
-                
+
                     teamFiles.push(thisFile);
                 })
             } else {
@@ -228,23 +226,22 @@ export async function fetchTeamForms() {
         return myTeams;
     });
 
-    const baseUrl = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://socket.graphitedocs.com';
     const data = {
-        profile: userSession.loadUserData().profile, 
+        profile: userSession.loadUserData().profile,
         username: userSession.loadUserData().username
     }
     const pubKey = getPublicKeyFromPrivate(userSession.loadUserData().appPrivateKey);
     const bearer = blockstack.signProfileToken(data, userSession.loadUserData().appPrivateKey);
     const headerObj = {
         headers: {
-            'Access-Control-Allow-Origin': '*', 
-            'Content-Type': 'application/json', 
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
             'Authorization': bearer
-        }, 
+        },
     }
 
     for(const team of myTeams) {
-        await axios.get(`${baseUrl}/account/organization/${orgId}/teams/${team.id}/forms?pubKey=${pubKey}`, headerObj)
+        await axios.get(`/account/organization/${orgId}/teams/${team.id}/forms?pubKey=${pubKey}`, headerObj)
         .then(async (res) => {
             if(res.data.data) {
                 const forms = res.data.data;
@@ -254,14 +251,14 @@ export async function fetchTeamForms() {
                     decrypt: true,
                 }
                 const fetchedKeys = await fetchData(teamKeyParams);
-                
+
                 // const thisDoc = userSession.decryptContent(JSON.parse(res.data.data), {privateKey: privateKey});
                 asyncForEach(forms, (form) => {
                     let thisForm = form;
                     //thisForm.currentHostBucket = thisForm.currentHostBucket;//userSession.decryptContent(thisForm.currentHostBucket, {privateKey: JSON.parse(fetchedKeys).private});
                     thisForm.teamName = userSession.decryptContent(thisForm.teamName, {privateKey: JSON.parse(fetchedKeys).private});
                     thisForm.title = userSession.decryptContent(thisForm.title, {privateKey: JSON.parse(fetchedKeys).private});
-                
+
                     teamForms.push(thisForm);
                 })
             } else {

--- a/src/index.js
+++ b/src/index.js
@@ -9,16 +9,28 @@ import { configure } from 'radiks';
 import { UserSession } from 'blockstack';
 import { appConfig } from './utils/config';
 import initialValue from './components/docs/views/editor/initialValue.json';
+import axios from 'axios'
 
 const avatarFallbackImage = 'https://s3.amazonaws.com/onename/avatar-placeholder.png';
 
 const userSession = new UserSession({ appConfig })
 const port = window.location.href.includes('local') ? 'http://localhost:5000' : 'https://whispering-sands-47101.herokuapp.com';
 
+const setAxiosHeaders = () => {
+  // Default
+  // axios.defaults.baseURL = process.env.NODE_ENV === 'development' ? process.env.REACT_APP_API_URL_LOCAL : process.env.REACT_APP_API_URL_SOCKET
+
+  // Local w/ sockets
+  axios.defaults.baseURL = process.env.REACT_APP_API_URL_SOCKET
+
+  // Local w/o sockets
+  // axios.defaults.baseURL = process.env.REACT_APP_API_URL_LOCAL
+}
+
 setGlobal({
     userSession,
     organization: {},
-    documents: [], 
+    documents: [],
     contacts: [],
     files: [],
     teams: [],
@@ -252,20 +264,20 @@ setGlobal({
     timelineEventTextHeadline: "",
     timelineEventTextText: "",
     peopleList: [],
-    profileFound: false, 
-    response: {}, 
-    reAuth: false, 
+    profileFound: false,
+    response: {},
+    reAuth: false,
     provider: "",
-    shareModalOpen: false, 
+    shareModalOpen: false,
     tagModalOpen: false,
     deleteModalOpen: false,
-    selectedDoc: {}, 
+    selectedDoc: {},
     sharedDocs: [],
     sharedFiles: [],
     fileProcessing: false,
-    vaultModalOpen: false, 
-    sharefileModalOpen: false, 
-    vaultPublicModalOpen: false, 
+    vaultModalOpen: false,
+    sharefileModalOpen: false,
+    vaultPublicModalOpen: false,
     contactModalOpen: false,
     trialModalOpen: false,
     orgNameModalOpen: false,
@@ -273,54 +285,55 @@ setGlobal({
     newTeamMateModalOpen: false,
     teamListModalOpen: false,
     contact: {},
-    sharedCollectionLoading: false, 
-    welcome: false, 
-    newTeamName: "", 
-    selectedTeam: "", 
-    settingsNav: "org", 
-    teamKeys: "", 
-    teamShare: false, 
-    contactEditing: false, 
-    newNote: "", 
-    contactNotes: [], 
+    sharedCollectionLoading: false,
+    welcome: false,
+    newTeamName: "",
+    selectedTeam: "",
+    settingsNav: "org",
+    teamKeys: "",
+    teamShare: false,
+    contactEditing: false,
+    newNote: "",
+    contactNotes: [],
     formTitleSaved: false,
-    formLinkModalOpen: false, 
-    formEmbedModalOpen: false, 
-    teamForms: [], 
+    formLinkModalOpen: false,
+    formEmbedModalOpen: false,
+    teamForms: [],
     formResponses: [],
-    submitted: false, 
-    embed: "", 
+    submitted: false,
+    embed: "",
     teamId: "",
     document: {},
     comments: [],
-    currentColor: {}, 
-    currentHighlight: {}, 
-    currentFont: {}, 
+    currentColor: {},
+    currentHighlight: {},
+    currentFont: {},
     currentTextType: {},
-    currentHeading: "", 
+    currentHeading: "",
     currentFontSize: {},
-    boldApplied: false, 
-    italicsApplied: false, 
-    underlineApplied: false, 
-    strikeApplied: false, 
-    alignment: "left", 
-    nodeType: "", 
+    boldApplied: false,
+    italicsApplied: false,
+    underlineApplied: false,
+    strikeApplied: false,
+    alignment: "left",
+    nodeType: "",
     marginTop: 1,
     marginBottom: 1,
     marginLeft: 1,
-    marginRight: 1, 
-    orientation: "portrait", 
-    tableSize: "1x1", 
+    marginRight: 1,
+    orientation: "portrait",
+    tableSize: "1x1",
     tableOfContents: [],
-    docOutline: [], 
+    docOutline: [],
     pages: 0,
-    allComments: [], 
+    allComments: [],
     paragraphs: 0,
     sentences: 0,
     charactersNoSpaces: 0,
     charactersSpaces: 0
 })
 
+setAxiosHeaders()
 configure({
     apiServer: port,
     userSession

--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,12 @@ const port = window.location.href.includes('local') ? 'http://localhost:5000' : 
 
 const setAxiosHeaders = () => {
   // Default
-  // axios.defaults.baseURL = process.env.NODE_ENV === 'development' ? process.env.REACT_APP_API_URL_LOCAL : process.env.REACT_APP_API_URL_SOCKET
+  axios.defaults.baseURL = process.env.NODE_ENV === 'development' ? process.env.REACT_APP_API_URL_LOCAL : process.env.REACT_APP_API_URL_SOCKET
 
-  // Local w/ sockets
-  axios.defaults.baseURL = process.env.REACT_APP_API_URL_SOCKET
+  // Local w/ sockets (PRO)
+  // axios.defaults.baseURL = process.env.REACT_APP_API_URL_SOCKET
 
-  // Local w/o sockets
+  // Local w/o sockets (Normal)
   // axios.defaults.baseURL = process.env.REACT_APP_API_URL_LOCAL
 }
 


### PR DESCRIPTION
- I set the global axios defaults for fetching in the `src/index.js`.  
- This will reduce the amount of boilerplate necessary when making axios request.
- When user pulls locally, they should have the option to keep as is, pro feature, or normal graphite features via below (`src/index.js`)

```
// src/index.js
const setAxiosHeaders = () => {
  // Default
  axios.defaults.baseURL = process.env.NODE_ENV === 'development' ? process.env.REACT_APP_API_URL_LOCAL : process.env.REACT_APP_API_URL_SOCKET

  // Local w/ sockets (PRO)
  // axios.defaults.baseURL = process.env.REACT_APP_API_URL_SOCKET

  // Local w/o sockets (Normal)
  // axios.defaults.baseURL = process.env.REACT_APP_API_URL_LOCAL
}
```

- Add two files `.env` and `.env.sample`.  By default `.env` will be a git ignored file.  `.env.config.js` will be added as github and SHOULD NOT contain sensitive data as it is exposed like public API KEYS.
- Updated the Readme on #4 to copy the env.config.js to `.env`

- Don't merge this in yet.  I need to test this later tonight but putting in a PR to show the changes.
